### PR TITLE
Add and apply code style conventions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.py]
+max_line_length = 88
+
+[*.yml]
+indent_size = 2

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 *.pyc
+poetry.lock

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,30 @@
+# See https://pre-commit.com/hooks.html for info on hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.2.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-ast
+      - id: check-toml
+      - id: check-yaml
+      - id: debug-statements
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: trailing-whitespace
+
+  - repo: https://github.com/psf/black
+    rev: 19.10b0
+    hooks:
+      - id: black
+
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.3
+    hooks:
+      - id: flake8
+        args: [--max-line-length=88]
+        language_version: python3.7
+
+  - repo: https://github.com/timothycrosley/isort
+    rev: 5.4.2
+    hooks:
+      - id: isort

--- a/pelican/plugins/pelimoji/__init__.py
+++ b/pelican/plugins/pelimoji/__init__.py
@@ -1,1 +1,1 @@
-from .pelimoji import *
+from .pelimoji import *  # NOQA

--- a/pelican/plugins/pelimoji/pelimoji.py
+++ b/pelican/plugins/pelimoji/pelimoji.py
@@ -44,7 +44,7 @@ def init(pelican_object):
     # compile pattern to global for speed, given how massive it'll (potentially) be
     pelimoji_prog = re.compile(pattern)
     # And the pattern to replace it with!
-    pelimoji_replace = '<i class="cemoji cemoji-\g<emoji>" title=":\g<emoji>:"><span>:\g<emoji>:</span></i>'
+    pelimoji_replace = r'<i class="cemoji cemoji-\g<emoji>" title=":\g<emoji>:"><span>:\g<emoji>:</span></i>'
 
 
 def replace(content):
@@ -52,7 +52,7 @@ def replace(content):
     if fileext in ["md", "html", "rst", "txt"]:
         try:
             content._content = pelimoji_prog.sub(pelimoji_replace, content._content)
-        except:
+        except TypeError:
             print(
                 "Something went wrong editing {} for pelimoji, sorry".format(
                     str(content)

--- a/pelican/plugins/pelimoji/pelimoji.py
+++ b/pelican/plugins/pelimoji/pelimoji.py
@@ -12,40 +12,52 @@ def init(pelican_object):
     # Global emojis, prefix
     global pelimoji_prog, pelimoji_replace
     # Let's build a list of installed emoji
-    content_root = pelican_object.settings.get('PATH',())
+    content_root = pelican_object.settings.get("PATH", ())
     search_path = "%s/emoji" % (content_root,)
     output_path = "emoji_map"
-    save_path = "%s/%s" % (content_root,output_path)
-    pelican_object.settings['STATIC_PATHS'].append(output_path)
-    prefix = pelican_object.settings.get('PELIMOJI_PREFIX',"")
+    save_path = "%s/%s" % (content_root, output_path)
+    pelican_object.settings["STATIC_PATHS"].append(output_path)
+    prefix = pelican_object.settings.get("PELIMOJI_PREFIX", "")
     if prefix != "":
         prefix = prefix + "-"
-    installed_emoji = subprocess.check_output(['find',search_path,'-iname',"*.png"]).split(b'\n')
+    installed_emoji = subprocess.check_output(
+        ["find", search_path, "-iname", "*.png"]
+    ).split(b"\n")
     # Now using 'glue' to make the sprite sheet itself
-    glue_exec = ['glue',search_path, save_path, \
-        '--namespace',"cemoji", \
-        '--sprite-namespace',"", \
-        f'--css-template={PLUGIN_ROOT}/pelimoji/css.j2', \
-        '--recursive',
-        '--cachebuster' ]
+    glue_exec = [
+        "glue",
+        search_path,
+        save_path,
+        "--namespace",
+        "cemoji",
+        "--sprite-namespace",
+        "",
+        f"--css-template={PLUGIN_ROOT}/pelimoji/css.j2",
+        "--recursive",
+        "--cachebuster",
+    ]
     subprocess.call(glue_exec)
     # Now let's create a search-list of emoji names
-    emojis = [ basename(x.decode('utf-8'))[:-4] for x in installed_emoji ]
+    emojis = [basename(x.decode("utf-8"))[:-4] for x in installed_emoji]
     # And a regex pattern to find to avoid iterating
     pattern = ":" + prefix + "(?P<emoji>(" + ")|(".join(emojis) + ")):"
     # compile pattern to global for speed, given how massive it'll (potentially) be
     pelimoji_prog = re.compile(pattern)
     # And the pattern to replace it with!
-    pelimoji_replace = "<i class=\"cemoji cemoji-\g<emoji>\" title=\":\g<emoji>:\"><span>:\g<emoji>:</span></i>"
+    pelimoji_replace = '<i class="cemoji cemoji-\g<emoji>" title=":\g<emoji>:"><span>:\g<emoji>:</span></i>'
 
 
 def replace(content):
-    fileext = str(content).split('.')[-1].lower()
-    if fileext in ['md','html','rst','txt']:
+    fileext = str(content).split(".")[-1].lower()
+    if fileext in ["md", "html", "rst", "txt"]:
         try:
-            content._content = pelimoji_prog.sub(pelimoji_replace,content._content)
+            content._content = pelimoji_prog.sub(pelimoji_replace, content._content)
         except:
-            print("Something went wrong editing {} for pelimoji, sorry".format(str(content)))
+            print(
+                "Something went wrong editing {} for pelimoji, sorry".format(
+                    str(content)
+                )
+            )
 
 
 def register():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,58 @@
+[tool.poetry]
+name = "pelimoji"
+version = "0.0.0"
+description = "Pelican plugin for simple emoji replacement"
+authors = ["Kay Ohtie <kay@coyotesin.space>"]
+license = "AGPL-3.0"
+readme = "README.md"
+keywords = ["pelican", "plugin", "emoji"]
+repository = "https://github.com/pelican-plugins/pelimoji"
+documentation = "https://docs.getpelican.com"
+packages = [
+    { include = "pelican" },
+]
+
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
+    "Framework :: Pelican",
+    "Framework :: Pelican :: Plugins",
+    "Intended Audience :: End Users/Desktop",
+    "License :: OSI Approved :: GNU Affero General Public License v3",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.6",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Topic :: Internet :: WWW/HTTP",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+
+[tool.poetry.urls]
+"Funding" = "https://donate.getpelican.com/"
+"Tracker" = "https://github.com/pelican-plugins/pelimoji/issues"
+
+[tool.poetry.dependencies]
+python = "^3.6"
+pelican = "^4.2"
+jinja2 = "=2.9.6"
+glue = "^0.13"
+markdown = {version = "^3.2.2",optional = true}
+
+[tool.poetry.dev-dependencies]
+black = {version = "^19.10b0",allow-prereleases = true}
+flake8 = "^3.8"
+flake8-black = "^0.1.0"
+invoke = "^1.3"
+isort = "^5.4"
+livereload = "^2.6"
+markdown = "^3.2.2"
+Werkzeug = "^1.0"
+
+[tool.poetry.extras]
+markdown = ["markdown"]
+
+[build-system]
+requires = ["poetry>=1.0"]
+build-backend = "poetry.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,17 @@ Werkzeug = "^1.0"
 [tool.poetry.extras]
 markdown = ["markdown"]
 
+[tool.isort]
+# Maintain compatibility with Black
+combine_as_imports = true
+force_grid_wrap = 0
+include_trailing_comma = true
+line_length = 88
+multi_line_output = 3
+
+# Sort imports within their section independent of the import type
+force_sort_within_sections = true
+
 [build-system]
 requires = ["poetry>=1.0"]
 build-backend = "poetry.masonry.api"

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,79 @@
+import os
+from pathlib import Path
+from shutil import which
+
+from invoke import task
+
+PKG_NAME = "pelimoji"
+PKG_PATH = Path(f"pelican/plugins/{PKG_NAME}")
+ACTIVE_VENV = os.environ.get("VIRTUAL_ENV", None)
+VENV_HOME = Path(os.environ.get("WORKON_HOME", "~/.local/share/virtualenvs"))
+VENV_PATH = Path(ACTIVE_VENV) if ACTIVE_VENV else (VENV_HOME / PKG_NAME)
+VENV = str(VENV_PATH.expanduser())
+
+TOOLS = ["poetry", "pre-commit"]
+POETRY = which("poetry") if which("poetry") else (VENV / Path("bin") / "poetry")
+PRECOMMIT = (
+    which("pre-commit") if which("pre-commit") else (VENV / Path("bin") / "pre-commit")
+)
+
+
+@task
+def tests(c):
+    """Run the test suite"""
+    c.run(f"{VENV}/bin/pytest", pty=True)
+
+
+@task
+def black(c, check=False, diff=False):
+    """Run Black auto-formatter, optionally with --check or --diff"""
+    check_flag, diff_flag = "", ""
+    if check:
+        check_flag = "--check"
+    if diff:
+        diff_flag = "--diff"
+    c.run(f"{VENV}/bin/black {check_flag} {diff_flag} {PKG_PATH} tasks.py")
+
+
+@task
+def isort(c, check=False, diff=False):
+    check_flag, diff_flag = "", ""
+    if check:
+        check_flag = "-c"
+    if diff:
+        diff_flag = "--diff"
+    c.run(f"{VENV}/bin/isort {check_flag} {diff_flag} .")
+
+
+@task
+def flake8(c):
+    c.run(f"{VENV}/bin/flake8 {PKG_PATH} tasks.py")
+
+
+@task
+def lint(c):
+    isort(c, check=True)
+    black(c, check=True)
+    flake8(c)
+
+
+@task
+def tools(c):
+    """Install tools in the virtual environment if not already on PATH"""
+    for tool in TOOLS:
+        if not which(tool):
+            c.run(f"{VENV}/bin/pip install {tool}")
+
+
+@task
+def precommit(c):
+    """Install pre-commit hooks to .git/hooks/pre-commit"""
+    c.run(f"{PRECOMMIT} install")
+
+
+@task
+def setup(c):
+    c.run(f"{VENV}/bin/pip install -U pip")
+    tools(c)
+    c.run(f"{POETRY} install")
+    precommit(c)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+ignore = E203, E266, E501, W503


### PR DESCRIPTION
This adds the standard code style conventions from https://github.com/getpelican/cookiecutter-pelican-plugin to the Pelimoji project.

Also added here is a preliminary `pyproject.toml` (also generated via the above template), which is used for code style configuration but can also later be used to publish the plugin to PyPI.