### PR TITLE
Add CI-based linting & publishing via GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,68 @@
+name: build
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Set Poetry cache (Linux)
+        uses: actions/cache@v2
+        if: startsWith(runner.os, 'Linux')
+        with:
+          path: ~/.cache/pypoetry/virtualenvs
+          key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-
+      - name: Upgrade Pip
+        run: python -m pip install -U pip
+      - name: Install Poetry
+        run: python -m pip install poetry
+      - name: Install dependencies
+        run: |
+          poetry run pip install -U pip
+          poetry run pip install -e git://github.com/getpelican/pelican.git#egg=pelican
+          poetry install
+      - name: Run linters
+        run: poetry run invoke lint
+
+
+  deploy:
+    name: Deploy
+    needs: [lint]
+    runs-on: ubuntu-latest
+    if: ${{ github.ref=='refs/heads/master' && github.event_name!='pull_request' }}
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Check release
+        id: check_release
+        run: |
+          python -m pip install pip --upgrade
+          pip install poetry
+          pip install githubrelease
+          pip install autopub
+          echo "##[set-output name=release;]$(autopub check)"
+      - name: Publish
+        if: ${{ steps.check_release.outputs.release=='' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          git remote set-url origin https://$GITHUB_TOKEN@github.com/${{ github.repository }}
+          autopub prepare
+          poetry build
+          autopub commit
+          autopub githubrelease
+          poetry publish -u __token__ -p $PYPI_PASSWORD


### PR DESCRIPTION
This adds configuration for continuous integration (CI) via GitHub Actions. While CI is often used to run tests, there aren't currently any tests for Pelimoji, so I left out the configuration related to running tests and instead focused on two things:

* code style "linting"
* publishing to PyPI (if a `RELEASE.md` file is present)