### PR TITLE
Set file extensions via `PELIMOJI_FILE_EXTENSIONS`

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ When compiling your site, the following directory will be created and automatica
 
 You may optionally also specify a `PELIMOJI_PREFIX` to require if you might have multiple sets of colon-tags that'd overlap. Whereas I might normally use `:thumbs-up:`, I could then specify `PELIMOJI_PREFIX = "emoji"`, and my tag would instead be `:emoji-thumbs-up:`.
 
+By default this plugin operates on source content files with the following file extensions: `["md", "html", "rst"]`, corresponding to Markdown, HTML, and reStructuredText. If you, say, want this plugin to also process files ending in `.txt`, you should add the following to your settings file:
+
+```python
+PELIMOJI_FILE_EXTENSIONS = ["md", "html", "rst", "txt"]
+```
+
 Contributing
 ------------
 

--- a/pelican/plugins/pelimoji/pelimoji.py
+++ b/pelican/plugins/pelimoji/pelimoji.py
@@ -13,8 +13,8 @@ logger = logging.getLogger(__name__)
 
 
 def init(pelican_object):
-    # Global emojis, prefix
-    global pelimoji_prog, pelimoji_replace
+    # Global variables for file extensions, emojis, prefix
+    global pelimoji_ext, pelimoji_prog, pelimoji_replace
     # Let's build a list of installed emoji
     content_root = Path(pelican_object.settings.get("PATH", ()))
     search_path = Path(
@@ -22,6 +22,9 @@ def init(pelican_object):
     )
     output_path = Path(content_root, "emoji_map")
     pelican_object.settings["STATIC_PATHS"].append(str(output_path))
+    pelimoji_ext = pelican_object.settings.get(
+        "PELIMOJI_FILE_EXTENSIONS", ["md", "html", "rst"]
+    )
     prefix = pelican_object.settings.get("PELIMOJI_PREFIX", "")
     output_map_path = "/emoji_map/emoji.png"
     if prefix:
@@ -100,7 +103,7 @@ def init(pelican_object):
 
 def replace(content):
     fileext = str(content).split(".")[-1].lower()
-    if fileext in ["md", "html", "rst", "txt"]:
+    if fileext in pelimoji_ext:
         try:
             content._content = pelimoji_prog.sub(pelimoji_replace, content._content)
         except TypeError:


### PR DESCRIPTION
## Problem

If you have files such as [`humans.txt`](https://humanstxt.org), [`robots.txt`](https://www.robotstxt.org), and/or [`security.txt`](https://securitytxt.org) in your source content, needless warnings are currently generated in the console output:

```
[08:38:51] WARNING  Something went wrong editing      log.py:91
                    content/extra/humans.txt for pelimoji, sorry

           WARNING  Something went wrong editing      log.py:91
                    content/extra/robots.txt for pelimoji, sorry
```

## Solution

Add a `PELIMOJI_FILE_EXTENSIONS` setting that defaults to `["md", "html", "rst"]` in order to prevent these warnings, while still allowing folks to configure this setting as needed in order to support `.txt`, `.markdown`, `.mkd`, `.mdown`, or any other file extensions they may want to be processed by Pelimoji.