### PR TITLE
Fixed fatal error with map path not existing

### DIFF
--- a/pelican/plugins/pelimoji/pelimoji.py
+++ b/pelican/plugins/pelimoji/pelimoji.py
@@ -26,7 +26,8 @@ def init(pelican_object):
             output_path.mkdir(parents=True)
         except Exception as e:
             logger.fatal(
-                f"Could not create required path for emoji data at '{output_path!s}': {e}"
+                f"Could not create required path for emoji data at '{output_path!s}' \
+                 {e}"
             )
     pelican_object.settings["STATIC_PATHS"].append(str(output_path))
     pelimoji_ext = pelican_object.settings.get(

--- a/pelican/plugins/pelimoji/pelimoji.py
+++ b/pelican/plugins/pelimoji/pelimoji.py
@@ -24,11 +24,13 @@ def init(pelican_object):
     if not output_path.exists():
         try:
             output_path.mkdir(parents=True, exist_ok=True)
-        except Exception as e:
+        except NotADirectoryError as e:
             logger.fatal(
-                f"Could not create required path for emoji data at '{output_path!s}' \
+                f"Non-directory file exists at '{output_path!s}' \
                  {e}"
             )
+        except PermissionError as e:
+            logger.fatal(f"Unable to create '{output_path!s}', permission error {e}")
     pelican_object.settings["STATIC_PATHS"].append(str(output_path))
     pelimoji_ext = pelican_object.settings.get(
         "PELIMOJI_FILE_EXTENSIONS", ["md", "html", "rst"]

--- a/pelican/plugins/pelimoji/pelimoji.py
+++ b/pelican/plugins/pelimoji/pelimoji.py
@@ -21,12 +21,17 @@ def init(pelican_object):
         content_root, pelican_object.settings.get("PELIMOJI_SOURCE", "emoji")
     )
     output_path = Path(content_root, "emoji_map")
+    if not output_path.exists():
+        try:
+            output_path.mkdir(parents=True)
+        except Exception as e:
+            logger.fatal(f"Could not create required path for emoji data at '{str(output_path)}': {e}")
     pelican_object.settings["STATIC_PATHS"].append(str(output_path))
     pelimoji_ext = pelican_object.settings.get(
         "PELIMOJI_FILE_EXTENSIONS", ["md", "html", "rst"]
     )
     prefix = pelican_object.settings.get("PELIMOJI_PREFIX", "")
-    output_map_path = "/emoji_map/emoji.png"
+    output_map_path = output_path / "emoji.png"
     if prefix:
         prefix = prefix + "-"
 
@@ -84,7 +89,7 @@ def init(pelican_object):
                 "height": image.size[1],
             }
         )
-    output_map.save(output_path / "emoji.png")
+    output_map.save(output_map_path)
     with open(Path(__file__).parent / "css.j2") as f:
         template = Template(f.read())
     with open(output_path / "emoji.css", "w") as f:

--- a/pelican/plugins/pelimoji/pelimoji.py
+++ b/pelican/plugins/pelimoji/pelimoji.py
@@ -31,7 +31,7 @@ def init(pelican_object):
         "PELIMOJI_FILE_EXTENSIONS", ["md", "html", "rst"]
     )
     prefix = pelican_object.settings.get("PELIMOJI_PREFIX", "")
-    output_map_path = output_path / "emoji.png"
+    output_map_path = "/emoji_map/emoji.png"
     if prefix:
         prefix = prefix + "-"
 
@@ -89,7 +89,7 @@ def init(pelican_object):
                 "height": image.size[1],
             }
         )
-    output_map.save(output_map_path)
+    output_map.save(output_path / "emoji.png")
     with open(Path(__file__).parent / "css.j2") as f:
         template = Template(f.read())
     with open(output_path / "emoji.css", "w") as f:

--- a/pelican/plugins/pelimoji/pelimoji.py
+++ b/pelican/plugins/pelimoji/pelimoji.py
@@ -25,7 +25,9 @@ def init(pelican_object):
         try:
             output_path.mkdir(parents=True)
         except Exception as e:
-            logger.fatal(f"Could not create required path for emoji data at '{output_path!s}': {e}")
+            logger.fatal(
+                f"Could not create required path for emoji data at '{output_path!s}': {e}"
+            )
     pelican_object.settings["STATIC_PATHS"].append(str(output_path))
     pelimoji_ext = pelican_object.settings.get(
         "PELIMOJI_FILE_EXTENSIONS", ["md", "html", "rst"]

--- a/pelican/plugins/pelimoji/pelimoji.py
+++ b/pelican/plugins/pelimoji/pelimoji.py
@@ -23,7 +23,7 @@ def init(pelican_object):
     output_path = Path(content_root, "emoji_map")
     if not output_path.exists():
         try:
-            output_path.mkdir(parents=True)
+            output_path.mkdir(parents=True, exist_ok=True)
         except Exception as e:
             logger.fatal(
                 f"Could not create required path for emoji data at '{output_path!s}' \

--- a/pelican/plugins/pelimoji/pelimoji.py
+++ b/pelican/plugins/pelimoji/pelimoji.py
@@ -113,9 +113,7 @@ def replace(content):
             content._content = pelimoji_prog.sub(pelimoji_replace, content._content)
         except TypeError:
             logger.warning(
-                "Something went wrong editing {} for pelimoji, sorry".format(
-                    str(content)
-                )
+                f"Something went wrong editing {content!s} for pelimoji, sorry"
             )
 
 

--- a/pelican/plugins/pelimoji/pelimoji.py
+++ b/pelican/plugins/pelimoji/pelimoji.py
@@ -25,7 +25,7 @@ def init(pelican_object):
         try:
             output_path.mkdir(parents=True)
         except Exception as e:
-            logger.fatal(f"Could not create required path for emoji data at '{str(output_path)}': {e}")
+            logger.fatal(f"Could not create required path for emoji data at '{output_path!s}': {e}")
     pelican_object.settings["STATIC_PATHS"].append(str(output_path))
     pelimoji_ext = pelican_object.settings.get(
         "PELIMOJI_FILE_EXTENSIONS", ["md", "html", "rst"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pelimoji"
-version = "1.0.0"
+version = "1.0.1"
 description = "Pelican plugin to add custom emoji to your site"
 authors = ["Kay Ohtie <kay@coyotesin.space>"]
 license = "AGPL-3.0"


### PR DESCRIPTION
If the output path did not exist, nothing created it causing a fatal write error. Pelimoji will now attempt to create the output path directory first, then write to it.

Erroneously changed variables and changed back. 