### PR TITLE
Add `PELIMOJI_SIZE_MULTIPLIER` configuration setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ By default this plugin operates on source content files with the following file 
 PELIMOJI_FILE_EXTENSIONS = ["md", "html", "rst", "txt"]
 ```
 
-`PELIMOJI_SIZE_MULTIPLIER` can be specified to increase the size of all emojis when they are rendered. It defaults to `1`; updating to `2` will cause each emoji to be twice as large; `3` will make them three times larger than the default size:
+You can specify a `PELIMOJI_SIZE_MULTIPLIER` setting, which defaults to `1`, to increase the size of all emoji when they are rendered. Specifying `2` via this setting will cause each emoji to be twice as large as the default, `3` will make them three times larger, et cetera. For example:
 ```python
 PELIMOJI_SIZE_MULTIPLIER = 2
 ```

--- a/README.md
+++ b/README.md
@@ -30,6 +30,11 @@ By default this plugin operates on source content files with the following file 
 PELIMOJI_FILE_EXTENSIONS = ["md", "html", "rst", "txt"]
 ```
 
+`PELIMOJI_SIZE_MULTIPLIER` can be specified to increase the size of all emojis when they are rendered
+```python
+PELIMOJI_SIZE_MULTIPLIER = 2
+```
+
 Contributing
 ------------
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ By default this plugin operates on source content files with the following file 
 PELIMOJI_FILE_EXTENSIONS = ["md", "html", "rst", "txt"]
 ```
 
-`PELIMOJI_SIZE_MULTIPLIER` can be specified to increase the size of all emojis when they are rendered
+`PELIMOJI_SIZE_MULTIPLIER` can be specified to increase the size of all emojis when they are rendered. It defaults to `1`; updating to `2` will cause each emoji to be twice as large; `3` will make them three times larger than the default size:
 ```python
 PELIMOJI_SIZE_MULTIPLIER = 2
 ```

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: minor
+
+Add size multiplier configuration setting to increase size of all emoji.

--- a/pelican/plugins/pelimoji/css.j2
+++ b/pelican/plugins/pelimoji/css.j2
@@ -1,14 +1,14 @@
 i.pelimoji {
     background-image: url('{{ output }}');
-    background-size: {{ grid.width / images[0].width }}em;
-    width: 1em;
-    height: 1em;
+    background-size: {{ (grid.width / images[0].width) * size_multiplier }}em;
+    width: {{ 1 * size_multiplier }}em;
+    height: {{1 * size_multiplier}}em;
     display: inline-block;
     object-fit: contain ! important;
     vertical-align: middle ! important;
 }
 {% for image in images %}
 .pelimoji-{{ image.stem }} {
-    background-position: -{{ image.position['x'] / image.width }}em {{ image.position['y'] / image.height }}em;
+    background-position: -{{ (image.position['x'] / image.width) * size_multiplier }}em {{ (image.position['y'] / image.height) * size_multiplier }}em;
 }
 {% endfor %}

--- a/pelican/plugins/pelimoji/pelimoji.py
+++ b/pelican/plugins/pelimoji/pelimoji.py
@@ -20,6 +20,7 @@ def init(pelican_object):
     search_path = Path(
         content_root, pelican_object.settings.get("PELIMOJI_SOURCE", "emoji")
     )
+    size_multiplier = pelican_object.settings.get("PELIMOJI_SIZE_MULTIPLIER", 1)
     output_path = Path(content_root, "emoji_map")
     if not output_path.exists():
         try:
@@ -68,6 +69,7 @@ def init(pelican_object):
             "height": grid_size[1],
         },
         "output": output_map_path,
+        "size_multiplier": size_multiplier,
     }
     image: Image
     for position, image in enumerate(images):


### PR DESCRIPTION
PELIMOJI_SIZE_MULTIPLIER expects a fairly small int that acts as a size multiplier for the displayed emojis. Closes #15.